### PR TITLE
feat: add OpenTelemetry (OTEL) instrumentation support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ required_modifiable_fields:
   - custom_download_password
 
 app_name: cloudagent
-__app_version: 26.4.25496
+__app_version: 26.4.25643
 
 darwin_installer_checksum: "676cd4cef57c4e3782c2db834ea8d91abd246d9812d49b36722e8e8b80c32530"
 windows_installer_checksum: "b220d615a139e10e486d01f1662214063a2724441a4bf62b714473e451995051"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ required_modifiable_fields:
   - custom_download_password
 
 app_name: cloudagent
-__app_version: 23.2.17459
+__app_version: 26.4.25487
 
 darwin_installer_checksum: "676cd4cef57c4e3782c2db834ea8d91abd246d9812d49b36722e8e8b80c32530"
 windows_installer_checksum: "b220d615a139e10e486d01f1662214063a2724441a4bf62b714473e451995051"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ required_modifiable_fields:
   - custom_download_password
 
 app_name: cloudagent
-__app_version: 26.4.25487
+__app_version: 26.4.25496
 
 darwin_installer_checksum: "676cd4cef57c4e3782c2db834ea8d91abd246d9812d49b36722e8e8b80c32530"
 windows_installer_checksum: "b220d615a139e10e486d01f1662214063a2724441a4bf62b714473e451995051"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ required_modifiable_fields:
   - custom_download_password
 
 app_name: cloudagent
-__app_version: 26.6.25935
+__app_version: 23.2.17459
 
 darwin_installer_checksum: "676cd4cef57c4e3782c2db834ea8d91abd246d9812d49b36722e8e8b80c32530"
 windows_installer_checksum: "b220d615a139e10e486d01f1662214063a2724441a4bf62b714473e451995051"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,40 @@ windows_installer_checksum: "b220d615a139e10e486d01f1662214063a2724441a4bf62b714
 service_name: "com.experitest.{{ app_name }}"
 main_class: "com.experitest.cloudagent.MainForwarder"
 
+# OpenTelemetry Configuration
+otel_enabled: false
+otel_version: "2.23.0"
+otel_download_url: "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v{{ otel_version }}/opentelemetry-javaagent.jar"
+otel_jar_name: "opentelemetry-javaagent.jar"
+otel_jar_full_path: "{{ installation_root_folder }}/otel/{{ otel_jar_name }}"
+
+otel_service_name: "{{ app_name }}"
+otel_environment: "prod"
+otel_namespace: "daict"
+otel_customer: "default"
+otel_alloy_endpoint: "http://{{ otel_alloy_host }}:{{ otel_alloy_port }}"
+otel_alloy_host: "localhost"
+otel_alloy_port: 4317
+
+otel_java_options:
+  - "-javaagent:{{ otel_jar_full_path }}"
+  - "-Dotel.service.name={{ otel_service_name }}"
+  - "-Dotel.resource.attributes=deployment.environment={{ otel_environment }},service.namespace={{ otel_namespace }},customer={{ otel_customer }}"
+  - "-Dotel.exporter.otlp.endpoint={{ otel_alloy_endpoint }}"
+  - "-Dotel.exporter.otlp.protocol=grpc"
+  - "-Dotel.metrics.exporter=otlp"
+  - "-Dotel.logs.exporter=otlp"
+
+# Keep user-provided extra JVM options separate from OTEL options
 extra_java_options: []
+
+# Add OTEL options only when enabled
+enabled_otel_java_options: "{{ otel_java_options if otel_enabled else [] }}"
+
+base_java_options: []
+
+# Final JVM options used by startup scripts/templates
+java_options: "{{ base_java_options + extra_java_options + enabled_otel_java_options }}"
 
 __server_port: 8081
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ required_modifiable_fields:
   - custom_download_password
 
 app_name: cloudagent
-__app_version: 26.4.25643
+__app_version: 26.6.25935
 
 darwin_installer_checksum: "676cd4cef57c4e3782c2db834ea8d91abd246d9812d49b36722e8e8b80c32530"
 windows_installer_checksum: "b220d615a139e10e486d01f1662214063a2724441a4bf62b714473e451995051"

--- a/tasks/darwin-install.yml
+++ b/tasks/darwin-install.yml
@@ -84,6 +84,22 @@
     owner: "{{ ansible_user_id }}"
   become: yes
 
+- name: Create directory for OTEL jar
+  file:
+    path: "{{ installation_root_folder }}/otel"
+    state: directory
+    owner: "{{ ansible_user_id }}"
+  become: yes
+  when: otel_enabled | bool
+
+- name: Download OpenTelemetry Java agent jar
+  get_url:
+    url: "{{ otel_download_url }}"
+    dest: "{{ otel_jar_full_path }}"
+    mode: '0644'
+    timeout: "{{ download_timeout | default(60) }}"
+  when: otel_enabled | bool
+
 - name: make sure unzip folder exist
   file:
     path: "{{ temp_folder }}/{{ (installer_file_name | splitext)[0] }}"

--- a/templates/start.bat.j2
+++ b/templates/start.bat.j2
@@ -11,5 +11,5 @@
     -Djdk.nio.maxCachedBufferSize=262144 ^
     -Djava.net.preferIPv4Stack=true ^
     -Djava.library.path=.;bin; ^
-    {{ extra_java_options | join(' ') }} ^
+    {{ java_options | join(' ') }} ^
     {{ main_class }}

--- a/templates/start.sh.j2
+++ b/templates/start.sh.j2
@@ -19,5 +19,5 @@ $JAVA_BIN -cp ".:lib/*" \
     -Dio.netty.noUnsafe=true \
     -Djdk.nio.maxCachedBufferSize=262144 \
     -Djava.library.path=./:./bin:./bin/native/darwin \
-    {{ extra_java_options | join(' ') }} \
+    {{ java_options | join(' ') }} \
     {{ main_class }}


### PR DESCRIPTION
## Summary
- Adds full OpenTelemetry signal correlation for traces, logs, and metrics via Grafana Alloy
- Fixes `stage.multiline` placement (moved to first stage) and corrects `firstline` regex to match actual Java log format (`YYYY-MM-DD HH:MM:SS`)
- Extracts only the `body` field from OTEL log JSON so Loki stores the raw log message instead of the full JSON envelope

## Test plan
- [ ] Deploy Alloy via Ansible and verify multiline Java stack traces are combined into single Loki entries
- [ ] Confirm OTEL logs in Loki contain only the log body (not the full JSON blob)
- [ ] Verify traces appear in Tempo with correct service graph metrics