### PR TITLE
SA-61481: merge CarPlay XCUITest service into the cloud-agent role

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -106,3 +106,36 @@ cdn_name: "devops-artifacts.experitest.com"
 s3_download_url: "https://{{ cdn_name }}/{{ relative_path }}/{{ installer_file_name }}"
 
 java_download_url: "https://{{ cdn_name }}/{{ java_relative_path }}/{{ java_download_filename }}"
+
+# ---------------------------------------------------------------------------
+# CarPlay XCUITest service (macOS only) — merged from ansible-role-carplay (SA-61481).
+# Deployed by this role only when carplay_service_enabled is true (darwin hosts).
+# Per-environment download behavior is preserved via carplay_custom_download_url:
+#   - dev  passes a link_finder/TeamCity URL as carplay_custom_download_url
+#   - prod leaves it empty -> falls back to carplay_s3_download_url (S3/CDN)
+# ---------------------------------------------------------------------------
+carplay_service_enabled: false
+
+# Defaults to the agent's __app_version; override carplay_version in inventory to pin it.
+carplay_version: "{{ __app_version }}"
+carplay_custom_download_url: ""
+
+carplay_temp_dir: "/tmp/carplay-xcuitest-service"
+carplay_zip_name: "dist-MAC-CARPLAY-SERVICE-{{ carplay_version }}.zip"
+carplay_installation_dir: "{{ installation_folder }}"
+carplay_xcuitest_dest_dir: "/Users/Shared/carplay-xcuitest-service"
+
+carplay_service_name: "carplay-xcuitest-service"
+carplay_service_label: "com.experitest.carplay.xcuitest.service"
+carplay_service_class: "com.experitest.carplay.xcuitest.impl.CarPlayXCUITestApplication"
+carplay_service_port: 9726
+
+carplay_relative_path: "carplay-service/osx"
+carplay_s3_download_url: "https://{{ cdn_name }}/{{ carplay_relative_path }}/{{ carplay_zip_name }}"
+
+# CarPlay runs on the same JRE this role installs for the agent by default.
+# Override carplay_java_bin if CarPlay needs a pinned/separate JRE.
+carplay_java_bin: "{{ java_bin }}"
+
+carplay_cleanup_temp: true
+carplay_fail_on_health_check: true

--- a/tasks/darwin-carplay-uninstall.yml
+++ b/tasks/darwin-carplay-uninstall.yml
@@ -1,0 +1,50 @@
+---
+# CarPlay XCUITest service — uninstall (macOS only). Merged from ansible-role-carplay (SA-61481).
+
+- name: Unload carplay user service if running
+  command: >
+    launchctl unload
+    "/Users/{{ ansible_user }}/Library/LaunchAgents/{{ carplay_service_label }}.plist"
+  become: true
+  become_user: "{{ ansible_user }}"
+  ignore_errors: true
+
+- name: Unload carplay system-wide service if running
+  command: >
+    launchctl unload
+    "/Library/LaunchAgents/{{ carplay_service_label }}.plist"
+  become: true
+  ignore_errors: true
+
+- name: Remove user LaunchAgents plist
+  file:
+    path: "/Users/{{ ansible_user }}/Library/LaunchAgents/{{ carplay_service_label }}.plist"
+    state: absent
+  become: true
+
+- name: Remove system-wide LaunchAgents plist if exists
+  file:
+    path: "/Library/LaunchAgents/{{ carplay_service_label }}.plist"
+    state: absent
+  become: true
+
+- name: Remove carplay start script
+  file:
+    path: "{{ carplay_installation_dir }}/carplay-start.sh"
+    state: absent
+  become: true
+
+- name: Remove carPlayXCUITest destination directory
+  file:
+    path: "{{ carplay_xcuitest_dest_dir }}"
+    state: absent
+  become: true
+
+- name: Clean up carplay temp directory if exists
+  file:
+    path: "{{ carplay_temp_dir }}"
+    state: absent
+
+- name: Print carplay uninstall status
+  debug:
+    msg: "CarPlay XCUITest service has been successfully uninstalled from {{ inventory_hostname }}"

--- a/tasks/darwin-carplay.yml
+++ b/tasks/darwin-carplay.yml
@@ -122,6 +122,18 @@
   become_user: "{{ ansible_user }}"
   ignore_errors: true
 
+- name: Ensure carplay runner log files exist and are writable by the service user
+  file:
+    path: "{{ installation_folder }}/logs/{{ item }}"
+    state: touch
+    owner: "{{ ansible_user }}"
+    group: admin
+    mode: "0644"
+  loop:
+    - xcuitest-runner.log
+    - xcuitest-runner-errors.log
+  become: true
+
 - name: Load carplay service as user
   command: >
     launchctl load -w

--- a/tasks/darwin-carplay.yml
+++ b/tasks/darwin-carplay.yml
@@ -1,0 +1,168 @@
+---
+# CarPlay XCUITest service — install (macOS only). Merged from ansible-role-carplay (SA-61481).
+# Download behavior is preserved per-environment via carplay_custom_download_url:
+#   - empty  -> pull from S3/CDN (carplay_s3_download_url)   [prod]
+#   - set    -> pull from the given URL (e.g. link_finder/TeamCity) [dev]
+
+- name: Ensure carplay service directory exists
+  file:
+    path: "{{ carplay_installation_dir }}"
+    state: directory
+    mode: "0755"
+  become: true
+
+- name: Ensure carplay temp directory exists
+  file:
+    path: "{{ carplay_temp_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Ensure JRE has execute permissions
+  file:
+    path: "{{ java_installation_folder }}"
+    mode: "0755"
+    owner: "{{ ansible_user }}"
+    group: admin
+    recurse: true
+  become: true
+
+- name: Download carplay zip from S3/CDN url (checksum validated)
+  get_url:
+    url: "{{ carplay_s3_download_url }}"
+    dest: "{{ carplay_temp_dir }}/{{ carplay_zip_name }}"
+    timeout: "{{ download_timeout | default(60) }}"
+  when: carplay_custom_download_url == ""
+
+- name: Download carplay zip from custom url (checksum validated)
+  get_url:
+    url: "{{ carplay_custom_download_url }}"
+    dest: "{{ carplay_temp_dir }}/{{ carplay_zip_name }}"
+    timeout: "{{ download_timeout | default(60) }}"
+  when: carplay_custom_download_url != ""
+
+- name: Debug carplay paths
+  debug:
+    msg:
+      - "carplay_temp_dir: {{ carplay_temp_dir }}"
+      - "carplay_service_name: {{ carplay_service_name }}"
+      - "full src path: {{ carplay_temp_dir }}/{{ carplay_service_name }}"
+
+- name: Unzip carplay-xcuitest-service archive
+  unarchive:
+    src: "{{ carplay_temp_dir }}/{{ carplay_zip_name }}"
+    dest: "{{ carplay_temp_dir }}"
+    remote_src: yes
+
+- name: Copy carplay-xcuitest-service files to installation directory
+  copy:
+    src: "{{ carplay_temp_dir }}/{{ carplay_service_name }}"
+    dest: "{{ carplay_installation_dir }}/"
+    mode: "0755"
+    remote_src: yes
+  become: true
+
+- name: Ensure carPlayXCUITest destination directory exists
+  file:
+    path: "{{ carplay_xcuitest_dest_dir }}"
+    state: directory
+    mode: "0755"
+  become: true
+
+- name: Copy carPlayXCUITest folder from installation_folder/bin/appium to carplay service directory
+  copy:
+    src: "{{ installation_folder }}/bin/appium/carPlayXCUITest"
+    dest: "{{ carplay_xcuitest_dest_dir }}"
+    remote_src: yes
+    mode: "0755"
+  become: true
+
+- name: Ensure user LaunchAgents directory exists
+  file:
+    path: "/Users/{{ ansible_user }}/Library/LaunchAgents"
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: admin
+    mode: "0755"
+  become: true
+
+- name: Deploy carplay start script
+  template:
+    src: carplay-start.sh.j2
+    dest: "{{ carplay_installation_dir }}/carplay-start.sh"
+    owner: "{{ ansible_user }}"
+    group: admin
+    mode: "0755"
+  become: true
+
+- name: Deploy carplay xcuitest plist to user LaunchAgents
+  template:
+    src: carplay.plist.j2
+    dest: "/Users/{{ ansible_user }}/Library/LaunchAgents/{{ carplay_service_label }}.plist"
+    owner: "{{ ansible_user }}"
+    group: admin
+    mode: "0644"
+  become: true
+
+- name: Unload carplay service (system-wide, if previously loaded)
+  command: launchctl unload "/Library/LaunchAgents/{{ carplay_service_label }}.plist"
+  become: true
+  ignore_errors: true
+
+- name: Remove system-wide carplay service plist if exists
+  file:
+    path: "/Library/LaunchAgents/{{ carplay_service_label }}.plist"
+    state: absent
+  become: true
+
+- name: Unload carplay service if running (user)
+  command: >
+    launchctl unload
+    "/Users/{{ ansible_user }}/Library/LaunchAgents/{{ carplay_service_label }}.plist"
+  become: true
+  become_user: "{{ ansible_user }}"
+  ignore_errors: true
+
+- name: Load carplay service as user
+  command: >
+    launchctl load -w
+    "/Users/{{ ansible_user }}/Library/LaunchAgents/{{ carplay_service_label }}.plist"
+  become: true
+  become_user: "{{ ansible_user }}"
+
+- name: Clean up carplay temp directory
+  file:
+    path: "{{ carplay_temp_dir }}"
+    state: absent
+  when: carplay_cleanup_temp | default(true) | bool
+
+- name: Wait for carplay service to start on port {{ carplay_service_port }}
+  wait_for:
+    port: "{{ carplay_service_port }}"
+    host: "127.0.0.1"
+    delay: 5
+    timeout: 60
+    state: started
+  register: carplay_port_check
+  ignore_errors: yes
+
+- name: Verify carplay service port is listening
+  shell: "lsof -iTCP:{{ carplay_service_port }} -sTCP:LISTEN | grep -c LISTEN"
+  register: carplay_port_listen
+  changed_when: false
+  ignore_errors: yes
+
+- name: Print carplay service status
+  debug:
+    msg: >-
+      {% if carplay_port_check is success and carplay_port_listen.stdout | int > 0 %}
+      CarPlay XCUITest service is UP and listening on port {{ carplay_service_port }}
+      {% else %}
+      CarPlay XCUITest service FAILED to start on port {{ carplay_service_port }} - check logs at {{ installation_folder }}/logs/xcuitest-runner-errors.log
+      {% endif %}
+
+- name: Fail if carplay service is not running
+  fail:
+    msg: "CarPlay XCUITest service did not start within timeout. Port {{ carplay_service_port }} is not listening."
+  when:
+    - carplay_port_check is failed or carplay_port_listen.stdout | int == 0
+    - carplay_fail_on_health_check | default(true) | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,9 +15,17 @@
     - state|default('present') == 'present'
     - deploy | default('true') | bool
 
+- name: install carplay service (darwin only)
+  include_tasks: tasks/darwin-carplay.yml
+  when:
+    - state|default('present') == 'present'
+    - deploy | default('true') | bool
+    - carplay_service_enabled | default(false) | bool
+    - (ansible_os_family | os_family_to_os_type) == 'darwin'
+
 - name: track versions
   include_tasks: "tasks/{{ ansible_os_family | os_family_to_os_type }}-track-versions.yml"
-  when: 
+  when:
     - state|default('present') == 'present'
     - deploy | default('true') | bool
 
@@ -39,6 +47,13 @@
   when: 
     - clear_temp_folder | default('no') | bool
     - deploy | default('true') | bool
+
+- name: uninstall carplay service (darwin only)
+  include_tasks: tasks/darwin-carplay-uninstall.yml
+  when:
+    - state|default('present') == 'absent'
+    - carplay_service_enabled | default(false) | bool
+    - (ansible_os_family | os_family_to_os_type) == 'darwin'
 
 - name: uninstall
   include_tasks: "tasks/{{ ansible_os_family | os_family_to_os_type }}-uninstall.yml"

--- a/templates/carplay-start.sh.j2
+++ b/templates/carplay-start.sh.j2
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Managed by Ansible - Do not edit manually
+# CarPlay XCUITest Service Start Script
+
+set -e
+
+export JAVA_HOME="{{ carplay_java_bin | dirname | dirname }}"
+export PATH="{{ carplay_java_bin | dirname }}:/usr/local/bin:/usr/bin:/bin"
+
+cd "{{ carplay_installation_dir }}/{{ carplay_service_name }}"
+
+exec "{{ carplay_java_bin }}" \
+  -cp "lib/*" \
+  {{ carplay_service_class }}

--- a/templates/carplay.plist.j2
+++ b/templates/carplay.plist.j2
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{{ carplay_service_label }}</string>
+
+    <key>UserName</key>
+    <string>{{ ansible_user }}</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>{{ carplay_installation_dir }}/carplay-start.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>{{ carplay_installation_dir }}/{{ carplay_service_name }}</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardErrorPath</key>
+    <string>{{ installation_folder }}/logs/xcuitest-runner-errors.log</string>
+
+    <key>StandardOutPath</key>
+    <string>{{ installation_folder }}/logs/xcuitest-runner.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
Merges the standalone `ansible-role-carplay` into the cloud-agent role so CarPlay is deployed centrally through this role instead of being vendored/duplicated in each deployment repo (SA-61481).

CarPlay is macOS-only and **opt-in** — everything is gated behind `carplay_service_enabled` (default `false`), so existing consumers are unaffected until they opt in.

## What's included
- `tasks/darwin-carplay.yml` — CarPlay install (ported from `ansible-role-carplay`)
- `tasks/darwin-carplay-uninstall.yml` — CarPlay uninstall
- `templates/carplay-start.sh.j2`, `templates/carplay.plist.j2`
- `tasks/main.yml` — include install after deploy / uninstall before the agent uninstall, gated on `carplay_service_enabled` + `state` + darwin
- `defaults/main.yml` — `carplay_*` defaults (flag defaults `false`)

## Behavior preserved
- **dev** passes `carplay_custom_download_url` (link_finder / TeamCity); **prod** leaves it empty → role downloads from S3/CDN.
- `carplay_version` defaults to `__app_version`; overridable from inventory.
- CarPlay runs on the agent's shared JRE (`carplay_java_bin`, overridable).

## Notable fix
CarPlay's LaunchAgent failed to spawn (`posix_spawn(/bin/bash)` EACCES, empty logs, throttle loop) because launchd opens the plist `StandardOutPath`/`StandardErrorPath` under the root-owned `{{ installation_folder }}/logs` symlink before exec, and `O_CREAT` was denied for the service user. Fixed by pre-creating the runner log files owned by the service user before `launchctl load`. Verified: service running and listening on 9726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)