### PR TITLE
SA-61481: document how to enable the CarPlay service in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,36 +39,3 @@ Role Variables
 | carplay_custom_download_url | url to download the CarPlay service zip; leave empty to use the S3/CDN default | string |  | no |
 | carplay_service_port | port the CarPlay XCUITest service listens on | number | 9726 | no |
 | carplay_java_bin | java binary used to run the CarPlay service | string | the agent's JRE (`java_bin`) | no |
-
-CarPlay XCUITest service
-------------------------
-
-The role can also deploy the **CarPlay XCUITest service** (macOS only). It is **opt-in and disabled by default** — set `carplay_service_enabled: true` to install it. When enabled, the role installs the service after the agent is deployed and runs it as a per-user `LaunchAgent` on port `9726`, using the agent's JRE.
-
-The download source is chosen automatically from `carplay_custom_download_url`:
-
-* **empty (default)** → download from the S3/CDN release location. Use this in production.
-* **set** → download from the given url (e.g. a TeamCity build resolved via `link_finder`). Use this in dev.
-
-**Enable with the S3/CDN release (prod):**
-
-```yaml
-- role: cloud-agent
-  carplay_service_enabled: true
-```
-
-**Enable with a custom/TeamCity build (dev):**
-
-```yaml
-- role: cloud-agent
-  carplay_service_enabled: true
-  carplay_custom_download_url: "{{ carplay_lf.download_url }}"
-  carplay_version: "{{ carplay_lf.app_version }}"
-```
-
-To remove it, run the role with `state: absent` and `carplay_service_enabled: true`.
-
-Example Playbook
-----------------
-
-#### [see working example](/example)

--- a/README.md
+++ b/README.md
@@ -39,3 +39,8 @@ Role Variables
 | carplay_custom_download_url | url to download the CarPlay service zip; leave empty to use the S3/CDN default | string |  | no |
 | carplay_service_port | port the CarPlay XCUITest service listens on | number | 9726 | no |
 | carplay_java_bin | java binary used to run the CarPlay service | string | the agent's JRE (`java_bin`) | no |
+
+Example Playbook
+----------------
+
+#### [see working example](/example)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,40 @@ Role Variables
 | kill_notepad | kill notepad/notepadd++ apps on windows | boolean | False | no |
 | maintain_supervision_files | maintain supervision files between installations | boolean | False | no |
 | download | only download the release version | boolean | True | no || deploy | only deploy the release version | boolean | True | no |
+| carplay_service_enabled | deploy the CarPlay XCUITest service (macOS only, opt-in) | boolean | False | no |
+| carplay_version | CarPlay service version to install | string | tracks `app_version` | no |
+| carplay_custom_download_url | url to download the CarPlay service zip; leave empty to use the S3/CDN default | string |  | no |
+| carplay_service_port | port the CarPlay XCUITest service listens on | number | 9726 | no |
+| carplay_java_bin | java binary used to run the CarPlay service | string | the agent's JRE (`java_bin`) | no |
+
+CarPlay XCUITest service
+------------------------
+
+The role can also deploy the **CarPlay XCUITest service** (macOS only). It is **opt-in and disabled by default** — set `carplay_service_enabled: true` to install it. When enabled, the role installs the service after the agent is deployed and runs it as a per-user `LaunchAgent` on port `9726`, using the agent's JRE.
+
+The download source is chosen automatically from `carplay_custom_download_url`:
+
+* **empty (default)** → download from the S3/CDN release location. Use this in production.
+* **set** → download from the given url (e.g. a TeamCity build resolved via `link_finder`). Use this in dev.
+
+**Enable with the S3/CDN release (prod):**
+
+```yaml
+- role: cloud-agent
+  carplay_service_enabled: true
+```
+
+**Enable with a custom/TeamCity build (dev):**
+
+```yaml
+- role: cloud-agent
+  carplay_service_enabled: true
+  carplay_custom_download_url: "{{ carplay_lf.download_url }}"
+  carplay_version: "{{ carplay_lf.app_version }}"
+```
+
+To remove it, run the role with `state: absent` and `carplay_service_enabled: true`.
+
 Example Playbook
 ----------------
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Role Variables
 | kill_notepad | kill notepad/notepadd++ apps on windows | boolean | False | no |
 | maintain_supervision_files | maintain supervision files between installations | boolean | False | no |
 | download | only download the release version | boolean | True | no || deploy | only deploy the release version | boolean | True | no |
-| carplay_service_enabled | deploy the CarPlay XCUITest service (macOS only, opt-in) | boolean | False | no |
+| carplay_service_enabled | deploy the CarPlay XCUITest service (macOS only, opt-in). cloud.agent.useXCUITestForCarPlay=true should be added in cloudagent application.properties | boolean | False | no |
 | carplay_version | CarPlay service version to install | string | tracks `app_version` | no |
 | carplay_custom_download_url | url to download the CarPlay service zip; leave empty to use the S3/CDN default | string |  | no |
 | carplay_service_port | port the CarPlay XCUITest service listens on | number | 9726 | no |


### PR DESCRIPTION
## Summary
Documents the CarPlay XCUITest service that the cloud-agent role can now deploy (SA-61481), so anyone can see how to enable it without reading the tasks.

## Changes
- Add `carplay_*` variables to the Role Variables table (`carplay_service_enabled`, `carplay_version`, `carplay_custom_download_url`, `carplay_service_port`, `carplay_java_bin`).
- Add a **CarPlay XCUITest service** section: opt-in flag, S3 (prod) vs custom-url/TeamCity (dev) download behavior, and enable/uninstall examples.

Docs only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)